### PR TITLE
Fix security block of web links in Mac build

### DIFF
--- a/Desktop/Code12/build.settings
+++ b/Desktop/Code12/build.settings
@@ -14,7 +14,7 @@ settings =
 	},
 
 	window =
-    {
+	{
 		defaultViewWidth = 600,
 		defaultViewHeight = 800,
 		minViewWidth = 320,
@@ -23,14 +23,25 @@ settings =
 		enableMaximizeButton = true,
 	},  
 
-    macos =
-    {
-        plist =
-        {
+	macos =
+	{
+		plist =
+		{
 			DeveloperURL = "http://www.code12.org/docs/1/API.html",
-            NSHumanReadableCopyright = "Copyright © 2019 Code12"
-        },
-    },
+			NSHumanReadableCopyright = "Copyright © 2019 Code12",
+			NSAppTransportSecurity =
+			{
+				NSExceptionDomains =
+				{
+					["code12.org"] =
+					{
+						NSIncludesSubdomains = true,
+						NSThirdPartyExceptionAllowsInsecureHTTPLoads = true,
+					},
+				},
+			},
+		},
+	},
 
 	--
 	-- Android section
@@ -53,6 +64,17 @@ settings =
 		{
 			UIStatusBarHidden = false,
 			UILaunchStoryboardName = "LaunchScreen",
+			NSAppTransportSecurity =
+			{
+				NSExceptionDomains =
+				{
+					["code12.org"] =
+					{
+						NSIncludesSubdomains = true,
+						NSThirdPartyExceptionAllowsInsecureHTTPLoads = true,
+					},
+				},
+			},
 		},
 	},
 

--- a/Doc/Website/download.html
+++ b/Doc/Website/download.html
@@ -46,9 +46,9 @@
   <h6>MacOS</h6>
   <ol>
     <li>Download <a href="downloads/Code12.dmg" download>Code12.dmg</a></li>
-    <li>Open the "Code12.dmg" file to show the contents.</li>
-    <li>Drag the enclosed "Code12.app" to your Applications folder.</li>
-    <li>Drag the app from Applications to your dock to create a shortcut.</li>
+    <li>Open the downloaded file to show the contents.</li>
+    <li>Drag the enclosed <b>Code12.app</b> to the <b>Applications</b> folder.</li>
+    <li>Open the <b>Applications</b> folder and drag the <b>Code12.app</b> inside it to your dock to create a shortcut.</li>
   </ol>
 
   <h4>Text Editors</h4>


### PR DESCRIPTION
Also now including a link to Applications in the Mac disk image download